### PR TITLE
Updated Lesson 7 Spreadsheet Scripts

### DIFF
--- a/lesson7/cpu_spreadsheet.py
+++ b/lesson7/cpu_spreadsheet.py
@@ -26,6 +26,14 @@ def login_open_sheet(oauth_key_file, spreadsheet):
 print('Logging sensor measurements to {0} every {1} seconds.'.format(GDOCS_SPREADSHEET_NAME, FREQUENCY_SECONDS))
 print('Press Ctrl-C to quit.')
 worksheet = None
+
+def find_previous_row(worksheet):
+  str_list = list(filter(None, worksheet.col_values(1)))
+  return len(str_list)
+
+def find_max_rows(worksheet):
+  return len(worksheet.get_all_values())
+
 while True:
     if worksheet is None:
         worksheet = login_open_sheet(GDOCS_OAUTH_JSON, GDOCS_SPREADSHEET_NAME)
@@ -39,7 +47,16 @@ while True:
     print('Memory Available: {0:0.1f} GB'.format(mem))
 #    print('Temperature: {0:0.1f} C'.format(tmp))
     try:
-        worksheet.append_row((str(dat), cpu, mem))
+        previous_row = find_previous_row(worksheet)
+        max_rows = find_max_rows(worksheet)
+        
+        if previous_row < max_rows:
+            worksheet.update_acell("A{}".format(previous_row), str(dat))
+            worksheet.update_acell("B{}".format(previous_row), cpu)
+            worksheet.update_acell("C{}".format(previous_row), mem)
+        else:
+            worksheet.append_row((str(dat), cpu, mem))
+        
 #        worksheet.append_row((dat, cpu, tmp))
 # gspread==0.6.2
 # https://github.com/burnash/gspread/issues/511  

--- a/lesson7/rpi_spreadsheet.py
+++ b/lesson7/rpi_spreadsheet.py
@@ -26,6 +26,14 @@ def login_open_sheet(oauth_key_file, spreadsheet):
 print('Logging sensor measurements to {0} every {1} seconds.'.format(GDOCS_SPREADSHEET_NAME, FREQUENCY_SECONDS))
 print('Press Ctrl-C to quit.')
 worksheet = None
+
+def find_previous_row(worksheet):
+  str_list = list(filter(None, worksheet.col_values(1)))
+  return len(str_list)
+
+def find_max_rows(worksheet):
+  return len(worksheet.get_all_values())
+
 while True:
     if worksheet is None:
         worksheet = login_open_sheet(GDOCS_OAUTH_JSON, GDOCS_SPREADSHEET_NAME)
@@ -36,7 +44,15 @@ while True:
     print('CPU Usage:   {0:0.1f} %'.format(cpu))
     print('Temperature: {0:0.1f} C'.format(tmp))
     try:
-        worksheet.append_row((str(dat), cpu, tmp))
+        previous_row = find_previous_row(worksheet)
+        max_rows = find_max_rows(worksheet)
+
+        if previous_row < max_rows:
+            worksheet.update_acell("A{}".format(previous_row), str(dat))
+            worksheet.update_acell("B{}".format(previous_row), cpu)
+            worksheet.update_acell("C{}".format(previous_row), tmp)
+        else:
+          worksheet.append_row((str(dat), cpu, tmp))
 #        worksheet.append_row((dat, cpu, tmp))
 # gspread==0.6.2
 # https://github.com/burnash/gspread/issues/511  


### PR DESCRIPTION
Updated the cpu_spreadsheet and rpi_spreadsheet scripts to be capable of functioning properly without the need to delete all empty rows before use.

In the instructions for the Google Sheets part of Lesson 7, it says that we need to delete rows 2 - 1000 before we start the script as it is designed to append data to the sheet, rather than check for the next empty row. I have made modifications to `cpu_spreadsheet.py` and `rpi_spreadsheet.py` to account for this.

To do this, I implemented two functions. The first is based on one that I found on a [Stack Overlow post](https://stackoverflow.com/questions/40781295/how-to-find-the-first-empty-row-of-a-google-spread-sheet-using-python-gspread/42476314#42476314) which helps me find the last row of the sheet that was filled in. The second is one that finds the total number of rows in the sheet.
```py
def find_previous_row(worksheet):
  str_list = list(filter(None, worksheet.col_values(1)))
  return len(str_list)

def find_max_rows(worksheet):
  return len(worksheet.get_all_values())
```

With a simple if statement, it is possible to check if the last used row is also the last row of the sheet. It it is, a new row is appended, and if not the next open row is used.
```py
previous_row = find_previous_row(worksheet)
max_rows = find_max_rows(worksheet)
        
if previous_row < max_rows:
  worksheet.update_acell("A{}".format(previous_row), str(dat))
  worksheet.update_acell("B{}".format(previous_row), cpu)
  worksheet.update_acell("C{}".format(previous_row), mem)
else:
  worksheet.append_row((str(dat), cpu, mem))
```

With these modifications, the need to delete all of the empty pre-generated rows is alleviated, while accounting for a user running out of rows!